### PR TITLE
Adding batch size argument for inference to fix memory error (#58)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,12 +6,12 @@ channels:
   - defaults
 dependencies:
   - python=3.11
-  - cudatoolkit=11.8
-  - cudnn=8.1.0
+  # - cudatoolkit=12.4
+  # - cudnn=8.1.0
   - pandas
   - pip
   - pytorch=2.2
-  - pytorch-cuda=11.8
+  - pytorch-cuda=12.4
   - torchvision
   - monai
   - numpy

--- a/fishjaw/model/model.py
+++ b/fishjaw/model/model.py
@@ -413,7 +413,7 @@ def train(
 def _predict_patches(
     net: torch.nn.Module,
     patches: tio.data.sampler.PatchSampler,
-    batch_size: int,
+    batch_size: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Make a prediction some patches
@@ -432,18 +432,15 @@ def _predict_patches(
     tensors = torch.cat(tensors, dim=0).to(device)
     locations = torch.stack(locations)
 
-    print(tensors.shape)
-
     predictions = []
     for i in range(0, len(tensors), batch_size):
-        batch = tensors[i:i + batch_size].to(device)
+        batch = tensors[i : i + batch_size].to(device)
         with torch.no_grad():
             prediction = net(batch).to("cpu").detach()
         predictions.append(prediction)
         torch.cuda.empty_cache()  # Clear CUDA cache to free up memory
 
     predictions = torch.cat(predictions, dim=0)
-
 
     return predictions, locations
 
@@ -465,7 +462,7 @@ def predict(
     :param patch_size: the size of the patches to use
     :param patch_overlap: the overlap between patches. Uses a hann window
     :param activation: the activation function to use
-    :param batch_size: the batch size to use
+    :param batch_size: the maximum number of patches that will be simultaneously sent to the model
 
     returns: the prediction, as a 3d numpy array
 

--- a/fishjaw/model/model.py
+++ b/fishjaw/model/model.py
@@ -438,8 +438,7 @@ def _predict_patches(
         with torch.no_grad():
             prediction = net(batch).to("cpu").detach()
         predictions.append(prediction)
-        torch.cuda.empty_cache()  # Clear CUDA cache to free up memory
-
+        
     predictions = torch.cat(predictions, dim=0)
 
     return predictions, locations

--- a/fishjaw/model/model.py
+++ b/fishjaw/model/model.py
@@ -454,7 +454,7 @@ def predict(
     batch_size: int = 1,
 ) -> np.ndarray:
     """
-    Make a prediction on a subject using the provided mosdel
+    Make a prediction on a subject using the provided model
 
     :param net: the model to use
     :param subject: the subject to predict on

--- a/fishjaw/model/model.py
+++ b/fishjaw/model/model.py
@@ -438,7 +438,7 @@ def _predict_patches(
         with torch.no_grad():
             prediction = net(batch).to("cpu").detach()
         predictions.append(prediction)
-        
+
     predictions = torch.cat(predictions, dim=0)
 
     return predictions, locations

--- a/fishjaw/model/model.py
+++ b/fishjaw/model/model.py
@@ -452,7 +452,7 @@ def predict(
     patch_size: tuple[int, int, int],
     patch_overlap: tuple[int, int, int],
     activation: str,
-    batch_size: int,
+    batch_size: int=1,
 ) -> np.ndarray:
     """
     Make a prediction on a subject using the provided model

--- a/fishjaw/model/model.py
+++ b/fishjaw/model/model.py
@@ -452,10 +452,10 @@ def predict(
     patch_size: tuple[int, int, int],
     patch_overlap: tuple[int, int, int],
     activation: str,
-    batch_size: int=1,
+    batch_size: int = 1,
 ) -> np.ndarray:
     """
-    Make a prediction on a subject using the provided model
+    Make a prediction on a subject using the provided mosdel
 
     :param net: the model to use
     :param subject: the subject to predict on

--- a/fishjaw/visualisation/images_3d.py
+++ b/fishjaw/visualisation/images_3d.py
@@ -60,7 +60,7 @@ def plot_inference(
     patch_size: tuple[int, int, int],
     patch_overlap: tuple[int, int, int],
     activation: str = "softmax",
-    batch_size: int,
+    batch_size: int = 1,
 ) -> matplotlib.figure.Figure:
     """
     Plot the inference on an image

--- a/fishjaw/visualisation/images_3d.py
+++ b/fishjaw/visualisation/images_3d.py
@@ -60,6 +60,7 @@ def plot_inference(
     patch_size: tuple[int, int, int],
     patch_overlap: tuple[int, int, int],
     activation: str = "softmax",
+    batch_size: int,
 ) -> matplotlib.figure.Figure:
     """
     Plot the inference on an image
@@ -77,6 +78,7 @@ def plot_inference(
         patch_size=patch_size,
         patch_overlap=patch_overlap,
         activation=activation,
+        batch_size=batch_size,
     )
 
     # Get the image from the subject

--- a/scripts/ablate_attention.py
+++ b/scripts/ablate_attention.py
@@ -134,6 +134,7 @@ def _predict(
     config: dict,
     inference_subject: tio.Subject,
     indices: tuple[int] | None = None,
+    batch_size: int = 1,
 ) -> np.ndarray:
     """
     Possibly disable some attention mechanism(s), Run inference
@@ -151,6 +152,7 @@ def _predict(
         patch_size=data.get_patch_size(config),
         patch_overlap=(4, 4, 4),
         activation=model.activation_name(config),
+        batch_size=batch_size,
     )
 
     # Put the attention mechanism back

--- a/scripts/explore_hyperparams.py
+++ b/scripts/explore_hyperparams.py
@@ -198,6 +198,7 @@ def step(
     data_config: data.DataConfig,
     out_dir: pathlib.Path,
     full_validation_subjects: list[tio.Subject],
+    batch_size: int = 1,
 ):
     """
     Get the right data, train the model and create some outputs
@@ -240,6 +241,7 @@ def step(
                 patch_size=data.get_patch_size(config),
                 patch_overlap=(4, 4, 4),
                 activation=activation,
+                batch_size=batch_size,
             )
             fig.savefig(str(out_dir / f"val_pred_{i}.png"))
             plt.close(fig)
@@ -263,6 +265,7 @@ def step(
                 patch_size=data.get_patch_size(config),
                 patch_overlap=(4, 4, 4),
                 activation=activation,
+                batch_size=batch_size,
             )
             np.save(out_dir / f"val_pred_{i}.npy", prediction)
             predictions.append(prediction)

--- a/scripts/inference_example.py
+++ b/scripts/inference_example.py
@@ -146,6 +146,7 @@ def _make_plots(
     subject: tio.Subject,
     config: dict,
     activation: str,
+    batch_size: int = 1,
 ) -> None:
     """
     Make the inference plots using a model and subject
@@ -173,6 +174,7 @@ def _make_plots(
         patch_size=data.get_patch_size(config),
         patch_overlap=(4, 4, 4),
         activation=activation,
+        batch_size=batch_size,
     )
 
     # Remove every second voxel to make the segmentation worse

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -104,8 +104,6 @@ def main():
         config, data_config, output_dir
     )
 
-    torch.cuda.empty_cache()
-
     # Save the model
     with open(str(model_path), "wb") as f:
         pickle.dump(
@@ -125,7 +123,7 @@ def main():
         patch_size=data.get_patch_size(config),
         patch_overlap=(4, 4, 4),
         activation=activation,
-        batch_size=config["batch_size"]
+        batch_size=config["batch_size"],
     )
     fig.savefig(str(output_dir / "test_pred.png"))
     plt.close(fig)

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -104,6 +104,8 @@ def main():
         config, data_config, output_dir
     )
 
+    torch.cuda.empty_cache()
+
     # Save the model
     with open(str(model_path), "wb") as f:
         pickle.dump(
@@ -123,6 +125,7 @@ def main():
         patch_size=data.get_patch_size(config),
         patch_overlap=(4, 4, 4),
         activation=activation,
+        batch_size=config["batch_size"]
     )
     fig.savefig(str(output_dir / "test_pred.png"))
     plt.close(fig)


### PR DESCRIPTION
Changes designed to address issue #58. 

When running the `scripts/train_model.py` script, I was getting an out of memory error at the point of inference. If I understand correctly, all patches were being passed to the model at once. Now we can make these predictions for smaller batches. (not sure if the terminology is right here but this seems to work!)

Please let me know if there's anything else I can do, I know we discussed some different ways of passing batch size argument.